### PR TITLE
WEBDEV-8531: Send Accept: application/json from fetchApiResponse

### DIFF
--- a/src/fetch-handler.ts
+++ b/src/fetch-handler.ts
@@ -63,7 +63,13 @@ export class FetchHandler implements FetchHandlerInterface {
     if (options?.includeCredentials) requestInit.credentials = 'include';
     if (options?.method) requestInit.method = options.method;
     if (options?.body) requestInit.body = options.body;
-    if (options?.headers) requestInit.headers = options.headers;
+    const headers = new Headers({ Accept: 'application/json' });
+    if (options?.headers) {
+      new Headers(options.headers).forEach((value, key) => {
+        headers.set(key, value);
+      });
+    }
+    requestInit.headers = headers;
     const response = await this.fetch(url, {
       requestInit: requestInit,
       retryConfig: options?.retryConfig,

--- a/test/fetch-handler.test.ts
+++ b/test/fetch-handler.test.ts
@@ -110,7 +110,7 @@ describe('Fetch Handler', () => {
       await fetchHandler.fetchApiResponse(endpoint, {
         includeCredentials: true,
       });
-      expect(fetchRetrier.init).to.deep.equal({ credentials: 'include' });
+      expect(fetchRetrier.init?.credentials).to.equal('include');
     });
 
     it('passes method, body, and headers to RequestInit', async () => {
@@ -122,11 +122,40 @@ describe('Fetch Handler', () => {
         body,
         headers: { 'x-test': '1', 'content-type': 'application/json' },
       });
-      expect(fetchRetrier.init).to.deep.equal({
-        method: 'POST',
-        body,
-        headers: { 'x-test': '1', 'content-type': 'application/json' },
+      expect(fetchRetrier.init?.method).to.equal('POST');
+      expect(fetchRetrier.init?.body).to.equal(body);
+      const headers = new Headers(fetchRetrier.init?.headers);
+      expect(headers.get('x-test')).to.equal('1');
+      expect(headers.get('content-type')).to.equal('application/json');
+    });
+
+    it('sends Accept: application/json by default', async () => {
+      const fetchRetrier = new MockFetchRetrier();
+      const fetchHandler = new FetchHandler({ fetchRetrier });
+      await fetchHandler.fetchApiResponse('https://example.org/api');
+      const headers = new Headers(fetchRetrier.init?.headers);
+      expect(headers.get('accept')).to.equal('application/json');
+    });
+
+    it('still sends Accept: application/json when caller supplies other headers', async () => {
+      const fetchRetrier = new MockFetchRetrier();
+      const fetchHandler = new FetchHandler({ fetchRetrier });
+      await fetchHandler.fetchApiResponse('https://example.org/api', {
+        headers: { 'x-test': '1' },
       });
+      const headers = new Headers(fetchRetrier.init?.headers);
+      expect(headers.get('accept')).to.equal('application/json');
+      expect(headers.get('x-test')).to.equal('1');
+    });
+
+    it('lets caller override the default Accept header', async () => {
+      const fetchRetrier = new MockFetchRetrier();
+      const fetchHandler = new FetchHandler({ fetchRetrier });
+      await fetchHandler.fetchApiResponse('https://example.org/api', {
+        headers: { Accept: 'text/plain' },
+      });
+      const headers = new Headers(fetchRetrier.init?.headers);
+      expect(headers.get('accept')).to.equal('text/plain');
     });
 
     it('passes retryConfig through to retrier', async () => {


### PR DESCRIPTION
Since fetchApiResponse always parses the response as JSON, advertise that expectation to the server via an Accept header. Caller-supplied headers override the default. Not blocking anything, just a tangential discovery. 

Totally optional, please reject if it takes more than 5 mins to review, or any amount of conversation/coordination...

===

EDIT: Filling in more of the info required in a PR:

Solves: [WEBDEV-8531: FetchHandler.fetchApiResponse() should send Accept: application/json header](https://webarchive.jira.com/browse/WEBDEV-8531)

QA steps [below](https://github.com/internetarchive/iaux-fetch-handler/pull/8#issuecomment-4631885681). 