### PR TITLE
WEBDEV-8617: Fix CI build failure by using bundler moduleResolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2018",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noEmitOnError": true,
     "lib": ["es2017", "dom"],
     "strict": true,


### PR DESCRIPTION
*(created using Claude)*

## Summary

`App CI` has been failing on `npm install` (the `prepare` → `tsc` step) with `TS7016` errors originating in `@open-wc/testing-helpers`' type declarations. This is a one-line `tsconfig.json` fix.

Ticket: **[WEBDEV-8617: Fetch Handler CI - build fails with TS7016 from scoped-elements exports map](https://webarchive.jira.com/browse/WEBDEV-8617)**

## Root cause

- `.github/workflows/ci.yml` does a **clean install** — it removes `node_modules` and `package-lock.json`, then runs `npm install` on `node-version: latest`. With the lockfile discarded, npm resolves the newest transitive deps, pulling in **`@open-wc/scoped-elements@3.0.10`** (via `@open-wc/testing@^4` → `@open-wc/testing-helpers@3.0.1`, which requires `^3.0.2`).
- `3.0.10` ships its type declarations **only** through the package `exports` map (`dist-types/html-element.d.ts`), with no sibling `.d.ts` next to `html-element.js`.
- Our `tsconfig.json` used classic **`moduleResolution: "node"`**, which does **not** honor `exports` maps. So `tsc` could not resolve the scoped-elements types referenced by `@open-wc/testing-helpers`' `.d.ts` files (pulled in via our `test/*.test.ts`) → `TS7016`. `noEmitOnError: true` then failed the build.
- It built locally only because the committed lockfile pinned `@open-wc/scoped-elements@3.0.6`, which still ships a sibling `.d.ts`. CI discards that lockfile.

## Change

`tsconfig.json`: `moduleResolution` `"node"` → `"bundler"`.

`bundler` honors `exports` maps and matches how this library's real (Vite / web-test-runner) consumers resolve it. It is compatible with the existing `module: "esnext"` and TypeScript 5.7.

**This is a resolution-only change** — `module`/emit and the published `dist/` artifact are unchanged. This package has no `exports` map of its own, so consumers resolve it identically via `main`/`module`/`types` regardless of this setting.

The CI clean-install strategy is intentional (early-warning for upstream dependency drift on a published library) and is **left as-is**; `bundler` preserves that signal while removing the false alarm that legacy `node` resolution raised against `exports`-map dependencies.

## Test / QA steps

Reproduced and verified locally against the exact version CI pulls:

```sh
npm install --no-save @open-wc/scoped-elements@3.0.10

# Control (pre-fix behavior) — reproduces the verbatim CI error:
npx tsc --noEmit --moduleResolution node   # → TS7016 on the two testing-helpers .d.ts files

# With the fix:
npx tsc --noEmit                           # → clean type-check
npm run test                               # tsc && lint && circular && wtr --coverage → 38 passed, 97.97% coverage
```

CI on this branch should now pass.

## Notes / out of scope

- husky prints a v10 deprecation warning (`.husky/pre-commit` bootstrap lines) and lint-staged warns its config still calls `git add`. Both pre-existing; not touched here.
