### PR TITLE
WEBDEV-8531: Send Accept: application/json from fetchApiResponse

### DIFF
--- a/src/fetch-handler.ts
+++ b/src/fetch-handler.ts
@@ -63,7 +63,13 @@ export class FetchHandler implements FetchHandlerInterface {
     if (options?.includeCredentials) requestInit.credentials = 'include';
     if (options?.method) requestInit.method = options.method;
     if (options?.body) requestInit.body = options.body;
-    if (options?.headers) requestInit.headers = options.headers;
+    const headers = new Headers({ Accept: 'application/json' });
+    if (options?.headers) {
+      new Headers(options.headers).forEach((value, key) => {
+        headers.set(key, value);
+      });
+    }
+    requestInit.headers = headers;
     const response = await this.fetch(url, {
       requestInit: requestInit,
       retryConfig: options?.retryConfig,

--- a/test/fetch-handler.test.ts
+++ b/test/fetch-handler.test.ts
@@ -110,7 +110,7 @@ describe('Fetch Handler', () => {
       await fetchHandler.fetchApiResponse(endpoint, {
         includeCredentials: true,
       });
-      expect(fetchRetrier.init).to.deep.equal({ credentials: 'include' });
+      expect(fetchRetrier.init?.credentials).to.equal('include');
     });
 
     it('passes method, body, and headers to RequestInit', async () => {
@@ -122,11 +122,40 @@ describe('Fetch Handler', () => {
         body,
         headers: { 'x-test': '1', 'content-type': 'application/json' },
       });
-      expect(fetchRetrier.init).to.deep.equal({
-        method: 'POST',
-        body,
-        headers: { 'x-test': '1', 'content-type': 'application/json' },
+      expect(fetchRetrier.init?.method).to.equal('POST');
+      expect(fetchRetrier.init?.body).to.equal(body);
+      const headers = new Headers(fetchRetrier.init?.headers);
+      expect(headers.get('x-test')).to.equal('1');
+      expect(headers.get('content-type')).to.equal('application/json');
+    });
+
+    it('sends Accept: application/json by default', async () => {
+      const fetchRetrier = new MockFetchRetrier();
+      const fetchHandler = new FetchHandler({ fetchRetrier });
+      await fetchHandler.fetchApiResponse('https://example.org/api');
+      const headers = new Headers(fetchRetrier.init?.headers);
+      expect(headers.get('accept')).to.equal('application/json');
+    });
+
+    it('still sends Accept: application/json when caller supplies other headers', async () => {
+      const fetchRetrier = new MockFetchRetrier();
+      const fetchHandler = new FetchHandler({ fetchRetrier });
+      await fetchHandler.fetchApiResponse('https://example.org/api', {
+        headers: { 'x-test': '1' },
       });
+      const headers = new Headers(fetchRetrier.init?.headers);
+      expect(headers.get('accept')).to.equal('application/json');
+      expect(headers.get('x-test')).to.equal('1');
+    });
+
+    it('lets caller override the default Accept header', async () => {
+      const fetchRetrier = new MockFetchRetrier();
+      const fetchHandler = new FetchHandler({ fetchRetrier });
+      await fetchHandler.fetchApiResponse('https://example.org/api', {
+        headers: { Accept: 'text/plain' },
+      });
+      const headers = new Headers(fetchRetrier.init?.headers);
+      expect(headers.get('accept')).to.equal('text/plain');
     });
 
     it('passes retryConfig through to retrier', async () => {


### PR DESCRIPTION
Solves: [WEBDEV-8531: FetchHandler.fetchApiResponse() should send Accept: application/json header](https://webarchive.jira.com/browse/WEBDEV-8531)

Replacement for: https://github.com/internetarchive/iaux-fetch-handler/pull/8

Since fetchApiResponse always parses the response as JSON, advertise that expectation to the server via an Accept header. Caller-supplied headers override the default. Not blocking anything, just a tangential discovery. 

## What changed
`FetchHandler.fetchApiResponse()` (and its callers `fetchApiPathResponse` / `fetchIAApiResponse`) now send `Accept: application/json` by default. Caller-supplied headers still merge in, and a caller can override `Accept` if they want.

## QA steps

1. **Check out the branch and install:**
   ```
   git fetch git@github.com:DuncanDHall/iaux-fetch-handler.git webdev-8531-fetchApiResponse-accept-applicationjson:webdev-8531-fetchApiResponse-accept-applicationjson
   git checkout webdev-8531-fetchApiResponse-accept-applicationjson
   npm install
   ```

2. **Run the demo:**
   ```
   npm start
   ```
   This serves the page at `demo/index.html` (typically `https://localhost:8000` — watch the terminal output for the actual URL).

3. **Open the page in a browser** with DevTools → Network tab open *before* the page loads (or hit the "Retry" button after opening DevTools).

4. **Verify default behavior** — find the request to `https://archive.org/metadata/goody`, click it, look at **Request Headers**:
   - ✅ Should see `Accept: application/json`

5. **Verify caller can still pass headers + Accept is preserved.** Edit `demo/app-root.ts` line 31 to pass a CORS-safelisted header (so no preflight is triggered):
   ```ts
   await this.fetchHandler.fetchApiPathResponse('/metadata/goody', {
     headers: { 'Accept-Language': 'en-US' },
   });
   ```
   Reload, inspect the request headers:
   - ✅ `Accept: application/json` still present
   - ✅ `Accept-Language: en-US` also present

   Note: avoid custom headers like `x-test` here — they trigger a CORS preflight that archive.org rejects, so the actual GET never sends and you can't read its headers.

6. **Verify caller can override Accept.** Change the demo to:
   ```ts
   await this.fetchHandler.fetchApiPathResponse('/metadata/goody', {
     headers: { Accept: 'text/plain' },
   });
   ```
   Reload, inspect request headers:
   - ✅ `Accept: text/plain` (the default was overridden, not duplicated)

7. **Revert any demo edits** when done.

8. **Run the unit tests** as a secondary check:
   ```
   npm test
   ```
   All tests should pass, including the three new ones in `test/fetch-handler.test.ts` ("sends Accept: application/json by default", "still sends Accept... when caller supplies other headers", "lets caller override the default Accept header").
