### PR TITLE
WEBDEV-8861: Gitignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 ## temp folders
 /.tmp/
 
+## git worktrees
+.claude/worktrees/
+
 # build
 /_site/
 /dist/


### PR DESCRIPTION
Worktrees under `.claude/worktrees/` were showing up as untracked files in the main checkout.

[WEBDEV-8861](https://webarchive.jira.com/browse/WEBDEV-8861)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWG9C3uwCAtAJUABguZnV9

[WEBDEV-8861]: https://webarchive.jira.com/browse/WEBDEV-8861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ